### PR TITLE
Add DisptachedTupleSet, bump version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DispatchedTuples"
 uuid = "508c55e1-51b4-41fd-a5ca-7eb0327d070d"
 authors = ["Charles Kawczynski <kawczynski.charles@gmail.com>"]
-version = "0.1.0"
+version = "0.1.1"
 
 [compat]
 julia = "1.5"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -45,6 +45,8 @@ For convenience, `DispatchedTuple` can alternatively take a `Tuple` of two-eleme
 ## API
 
 ```@docs
+DispatchedTuples.AbstractDispatchedTuple
 DispatchedTuples.DispatchedTuple
+DispatchedTuples.DispatchedTupleSet
 DispatchedTuples.dispatch
 ```

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,55 +4,39 @@ struct Foo end
 struct Bar end
 struct FooBar end
 
-tup = (
-    (Foo(), 1),
-    (Bar(), 2),
-    )
+#####
+##### DispatchedTuple's
+#####
 
-@testset "DispatchedTuples - error by default" begin
-    dt = DispatchedTuple(tup)
+@testset "DispatchedTuples - base behavior" begin
+    dt = DispatchedTuple(((Foo(), 1), (Bar(), 2)))
     @test dispatch(dt, Foo()) == (1,)
     @test dispatch(dt, Bar()) == (2,)
     @test_throws ErrorException dispatch(dt, FooBar())
-end
 
-@testset "DispatchedTuples - has default behavior" begin
-    dt = DispatchedTuple(tup, 0)
+    dt = DispatchedTuple(((Foo(), 1), (Bar(), 2)), 0)
     @test dispatch(dt, Foo()) == (1,)
     @test dispatch(dt, Bar()) == (2,)
     @test dispatch(dt, FooBar()) == (dt.default,)
 end
 
-tup = (
-    (Foo(), 1),
-    (Bar(), 2),
-    (Foo(), 3),
-    )
+@testset "DispatchedTuples - base behavior - Pair interface" begin
+    dt = DispatchedTuple((Pair(Foo(), 1), Pair(Bar(), 2)))
+    @test dispatch(dt, Foo()) == (1,)
+    @test dispatch(dt, Bar()) == (2,)
+    @test_throws ErrorException dispatch(dt, FooBar())
+
+    dt = DispatchedTuple((Pair(Foo(), 1), Pair(Bar(), 2)), 0)
+    @test dispatch(dt, Foo()) == (1,)
+    @test dispatch(dt, Bar()) == (2,)
+    @test dispatch(dt, FooBar()) == (dt.default,)
+end
 
 @testset "DispatchedTuples - multiple values" begin
-    dt = DispatchedTuple(tup)
+    dt = DispatchedTuple(((Foo(), 1), (Bar(), 2), (Foo(), 3)))
     @test dispatch(dt, Foo()) == (1,3)
     @test dispatch(dt, Bar()) == (2,)
     @test_throws ErrorException dispatch(dt, FooBar())
-end
-
-tup = (
-    Pair(Foo(), 1),
-    Pair(Bar(), 2),
-    )
-
-@testset "DispatchedTuples - Pair interface - error by default" begin
-    dt = DispatchedTuple(tup)
-    @test dispatch(dt, Foo()) == (1,)
-    @test dispatch(dt, Bar()) == (2,)
-    @test_throws ErrorException dispatch(dt, FooBar())
-end
-
-@testset "DispatchedTuples - Pair interface - has default behavior" begin
-    dt = DispatchedTuple(tup, 0)
-    @test dispatch(dt, Foo()) == (1,)
-    @test dispatch(dt, Bar()) == (2,)
-    @test dispatch(dt, FooBar()) == (dt.default,)
 end
 
 @testset "DispatchedTuples - extending" begin
@@ -65,4 +49,60 @@ end
     dt = DispatchedTuple(tup)
     @test length(dt) == length(tup)
     @test isempty(dt) == isempty(tup)
+end
+
+#####
+##### DispatchedTupleSet's
+#####
+
+@testset "DispatchedTupleSet - base behavior" begin
+    dt = DispatchedTupleSet(((Foo(), 1), (Bar(), 2)))
+    @test dispatch(dt, Foo()) == 1
+    @test dispatch(dt, Bar()) == 2
+    @test_throws ErrorException dispatch(dt, FooBar())
+
+    dt = DispatchedTupleSet(((Foo(), 1), (Bar(), 2)), 0)
+    @test dispatch(dt, Foo()) == 1
+    @test dispatch(dt, Bar()) == 2
+    @test dispatch(dt, FooBar()) == dt.default
+end
+
+@testset "DispatchedTupleSet - base behavior - Pair interface" begin
+    dt = DispatchedTupleSet((Pair(Foo(), 1), Pair(Bar(), 2)))
+    @test dispatch(dt, Foo()) == 1
+    @test dispatch(dt, Bar()) == 2
+    @test_throws ErrorException dispatch(dt, FooBar())
+end
+
+@testset "DispatchedTupleSet - multiple values, unique keys" begin
+    dt = DispatchedTupleSet(((Foo(), 1), (Bar(), 2), (Foo(), 3)))
+    @test_throws ErrorException dispatch(dt, Foo()) == 1
+    @test dispatch(dt, Bar()) == 2
+    @test_throws ErrorException dispatch(dt, FooBar())
+
+    dt = DispatchedTupleSet(((Foo(), 1), (Bar(), 2), (Foo(), 3)), 0)
+    @test_throws ErrorException dispatch(dt, Foo()) == 1
+    @test dispatch(dt, Bar()) == 2
+    @test dispatch(dt, FooBar()) == dt.default
+end
+
+@testset "DispatchedTuples - nested" begin
+    dtup_L1_a = DispatchedTupleSet(((Foo(), 1), (Bar(), 2)))
+    dtup_L1_b = DispatchedTupleSet(((Foo(), 3), (Bar(), 4)))
+    dtup_L1_c = DispatchedTupleSet(((Foo(), 5), (Bar(), 6)))
+    dtup_L1_d = DispatchedTupleSet(((Foo(), 7), (Bar(), 8)))
+
+    dtup_L2_a = DispatchedTupleSet(((Foo(), dtup_L1_a), (Bar(), dtup_L1_b)))
+    dtup_L2_b = DispatchedTupleSet(((Foo(), dtup_L1_c), (Bar(), dtup_L1_d)))
+
+    dtup_L3_a = DispatchedTupleSet(((Foo(), dtup_L2_a), (Bar(), dtup_L2_b)))
+
+    @test dispatch(dtup_L3_a, Foo(), Foo(), Foo()) == 1
+    @test dispatch(dtup_L3_a, Foo(), Foo(), Bar()) == 2
+    @test dispatch(dtup_L3_a, Foo(), Bar(), Foo()) == 3
+    @test dispatch(dtup_L3_a, Foo(), Bar(), Bar()) == 4
+    @test dispatch(dtup_L3_a, Bar(), Foo(), Foo()) == 5
+    @test dispatch(dtup_L3_a, Bar(), Foo(), Bar()) == 6
+    @test dispatch(dtup_L3_a, Bar(), Bar(), Foo()) == 7
+    @test dispatch(dtup_L3_a, Bar(), Bar(), Bar()) == 8
 end


### PR DESCRIPTION
This PR adds `DispatchedTupleSet`, and subtypes a newly added `AbstractDispatchedTuple`. `DispatchedTupleSet`'s require unique keys and return values instead of tuples of values.