### PR TITLE
Add DispatchedTupleDict, improve readme

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DispatchedTuples"
 uuid = "508c55e1-51b4-41fd-a5ca-7eb0327d070d"
 authors = ["Charles Kawczynski <kawczynski.charles@gmail.com>"]
-version = "0.1.2"
+version = "0.1.3"
 
 [compat]
 julia = "1.5"

--- a/README.md
+++ b/README.md
@@ -23,9 +23,23 @@
 [bors-img]: https://bors.tech/images/badge_small.svg
 [bors-url]: https://app.bors.tech/repositories/32073
 
-DispatchedTuples.jl defines one user-facing type: `DispatchedTuple`, and one user-facing method: `dispatch`. A `DispatchedTuple` is similar to a compile-time dictionary, that uses dispatch for the look-up.
+A `DispatchedTuple` is like a dictionary, except
 
-`DispatchedTuple` takes a `Tuple` of `Pair`s, where the `first` field of the `Pair` (the "key") is **an instance of the type you want to dispatch on**. The `second` field of the `Pair` is the quantity (the "value", which can be anything) returned by `dispatch`.
+ - the keys are **instances of types**
+ - they are backed by tuples, so they are GPU-friendly
+ - multiple keys are allowed (except for `DispatchedTupleSet`)
+ - each unique key returns a tuple of values given by that key (in order)
+
+All `AbstractDispatchedTuple`s take a `Tuple` of `Pair`s, where the `first` field of the `Pair` (the "key") is **an instance of the type you want to dispatch on**. The `second` field of the `Pair` is the quantity (the "value", which can be anything) returned by `dispatch(::AbstractDispatchedTuple, key)`, the one user-facing method exported by DispatchedTuples.jl.
+
+DispatchedTuples.jl has several user-facing types:
+
+ - `DispatchedTuple` - a dispatched tuple (example below)
+
+ - `DispatchedTupleSet` - a dispatched tuple set-- duplicate keys are not allowed. An error is thrown when `dispatch` is called with a duplicate key.
+
+ - `DispatchedTupleDict` - a dispatched tuple dict-- duplicate keys are allowed, but `dispatch` returns value from the last non-unique key.
+
 
 ## Example
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -48,5 +48,6 @@ For convenience, `DispatchedTuple` can alternatively take a `Tuple` of two-eleme
 DispatchedTuples.AbstractDispatchedTuple
 DispatchedTuples.DispatchedTuple
 DispatchedTuples.DispatchedTupleSet
+DispatchedTuples.DispatchedTupleDict
 DispatchedTuples.dispatch
 ```

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,6 +55,41 @@ end
 end
 
 #####
+##### DispatchedTupleDict's
+#####
+
+@testset "DispatchedTupleDict - base behavior" begin
+    dt = DispatchedTupleDict(((Foo(), 1), (Bar(), 2)))
+    @test dispatch(dt, Foo()) == 1
+    @test dispatch(dt, Bar()) == 2
+    @test_throws ErrorException dispatch(dt, FooBar())
+
+    dt = DispatchedTupleDict(((Foo(), 1), (Bar(), 2)), 0)
+    @test dispatch(dt, Foo()) == 1
+    @test dispatch(dt, Bar()) == 2
+    @test dispatch(dt, FooBar()) == dt.default
+end
+
+@testset "DispatchedTupleDict - base behavior - Pair interface" begin
+    dt = DispatchedTupleDict((Pair(Foo(), 1), Pair(Bar(), 2)))
+    @test dispatch(dt, Foo()) == 1
+    @test dispatch(dt, Bar()) == 2
+    @test_throws ErrorException dispatch(dt, FooBar())
+end
+
+@testset "DispatchedTupleDict - multiple values, unique keys" begin
+    dt = DispatchedTupleDict(((Foo(), 1), (Bar(), 2), (Foo(), 3)))
+    @test dispatch(dt, Foo()) == 3
+    @test dispatch(dt, Bar()) == 2
+    @test_throws ErrorException dispatch(dt, FooBar())
+
+    dt = DispatchedTupleDict(((Foo(), 1), (Bar(), 2), (Foo(), 3)), 0)
+    @test dispatch(dt, Foo()) == 3
+    @test dispatch(dt, Bar()) == 2
+    @test dispatch(dt, FooBar()) == dt.default
+end
+
+#####
 ##### DispatchedTupleSet's
 #####
 


### PR DESCRIPTION
This PR adds `DispatchedTupleDict`s, which allow multiple keys. Also, the README description is a bit improved. 