### PR TITLE
Change default behavior (push into empty tuple), remove DispatchedTupleDict

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ There are two kinds of `DispatchedTuple`s with different behavior:
 
 ```
 ┌────────────────────────────────────┬───────────────────────────┬────────────────────┐
-│                       Return value │           DispatchedTuple │ DispatchedTupleSet │
+│                       Return value │           DispatchedTuple │ DispatchedSet      │
 │                                    │ (non-unique keys allowed) │ (unique keys only) │
 ├────────────────────────────────────┼───────────────────────────┼────────────────────┤
 │                               Type │                     Tuple │              Value │
@@ -45,7 +45,7 @@ There are two kinds of `DispatchedTuple`s with different behavior:
 
 All `AbstractDispatchedTuple`s take a `Tuple` of `Pair`s, where the `first` field of the `Pair` (the "key") is **an instance of the type you want to dispatch on**. The `second` field of the `Pair` is the quantity (the "value", which can be anything) returned by `dispatch(::AbstractDispatchedTuple, key)`, the one user-facing method exported by DispatchedTuples.jl.
 
-Note that the second (optional) argument to `DispatchedTuple` and `DispatchedTupleSet` is a default value, which is returned for any unrecognized keys as shown in the table above.
+Note that the second (optional) argument to `DispatchedTuple` and `DispatchedSet` is a default value, which is returned for any unrecognized keys as shown in the table above.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -23,23 +23,29 @@
 [bors-img]: https://bors.tech/images/badge_small.svg
 [bors-url]: https://app.bors.tech/repositories/32073
 
-A `DispatchedTuple` is like a dictionary, except
+## What are dispatched tuples?
 
- - the keys are **instances of types**
- - they are backed by tuples, so they are GPU-friendly
- - multiple keys are allowed (except for `DispatchedTupleSet`)
- - each unique key returns a tuple of values given by that key (in order)
+`DispatchedTuple`s are like immutable dictionaries (so, they're more like `NamedTuple`s) except that the keys are **instances of types**. Also, because `DispatchedTuple`s are backed by tuples, they are GPU-friendly.
+
+There are two kinds of `DispatchedTuple`s with different behavior:
+
+```
+┌────────────────────────────────────┬───────────────────────────┬────────────────────┐
+│                       Return value │           DispatchedTuple │ DispatchedTupleSet │
+│                                    │ (non-unique keys allowed) │ (unique keys only) │
+├────────────────────────────────────┼───────────────────────────┼────────────────────┤
+│                               Type │                     Tuple │              Value │
+│ Unregistered key (without default) │                        () │              error │
+│    Unregistered key (with default) │                (default,) │            default │
+│                    Duplicative key │     all registered values │          one value │
+└────────────────────────────────────┴───────────────────────────┴────────────────────┘
+```
+
+## Creating and using dispatched tuples
 
 All `AbstractDispatchedTuple`s take a `Tuple` of `Pair`s, where the `first` field of the `Pair` (the "key") is **an instance of the type you want to dispatch on**. The `second` field of the `Pair` is the quantity (the "value", which can be anything) returned by `dispatch(::AbstractDispatchedTuple, key)`, the one user-facing method exported by DispatchedTuples.jl.
 
-DispatchedTuples.jl has several user-facing types:
-
- - `DispatchedTuple` - a dispatched tuple (example below)
-
- - `DispatchedTupleSet` - a dispatched tuple set-- duplicate keys are not allowed. An error is thrown when `dispatch` is called with a duplicate key.
-
- - `DispatchedTupleDict` - a dispatched tuple dict-- duplicate keys are allowed, but `dispatch` returns value from the last non-unique key.
-
+Note that the second (optional) argument to `DispatchedTuple` and `DispatchedTupleSet` is a default value, which is returned for any unrecognized keys as shown in the table above.
 
 ## Example
 
@@ -52,40 +58,22 @@ julia> struct Foo end;
 
 julia> struct Bar end;
 
-julia> dtup = DispatchedTuple((
-               Pair(Foo(), 1),
-               Pair(Bar(), 2),
-           ));
-
-julia> @show dispatch(dtup, Foo());
-dispatch(dtup, Foo()) = (1,)
-
-julia> @show dispatch(dtup, Bar());
-dispatch(dtup, Bar()) = (2,)
-```
-
-If a `DispatchedTuple` has duplicate keys, then all values are returned in the `Tuple`. Here's an example with duplicate keys:
-
-```julia
-julia> using DispatchedTuples
-
-julia> struct Foo end;
-
-julia> struct Bar end;
+julia> struct Baz end;
 
 julia> dtup = DispatchedTuple((
-               Pair(Foo(), 1),
-               Pair(Foo(), 3),
-               Pair(Bar(), 2),
-           ));
+          Pair(Foo(), 1),
+          Pair(Foo(), 2),
+          Pair(Bar(), 3),
+       ));
 
-julia> @show dispatch(dtup, Foo());
-dispatch(dtup, Foo()) = (1, 3)
+julia> dispatch(dtup, Foo())
+(1, 2)
 
-julia> @show dispatch(dtup, Bar());
-dispatch(dtup, Bar()) = (2,)
+julia> dispatch(dtup, Bar())
+(3,)
+
+julia> dispatch(dtup, Baz())
+()
 ```
-
-The second (optional) argument to `DispatchedTuple` is a default value, which is returned for any unrecognized keys. If the default value is not given, and `dispatch` is called with a key it hasn't seen, an error is thrown.
 
 For convenience, `DispatchedTuple` can alternatively take a `Tuple` of two-element `Tuple`s.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,7 +8,7 @@ There are two kinds of `DispatchedTuple`s with different behavior:
 
 ```
 ┌────────────────────────────────────┬───────────────────────────┬────────────────────┐
-│                       Return value │           DispatchedTuple │ DispatchedTupleSet │
+│                       Return value │           DispatchedTuple │ DispatchedSet      │
 │                                    │ (non-unique keys allowed) │ (unique keys only) │
 ├────────────────────────────────────┼───────────────────────────┼────────────────────┤
 │                               Type │                     Tuple │              Value │
@@ -22,7 +22,7 @@ There are two kinds of `DispatchedTuple`s with different behavior:
 
 All `AbstractDispatchedTuple`s take a `Tuple` of `Pair`s, where the `first` field of the `Pair` (the "key") is **an instance of the type you want to dispatch on**. The `second` field of the `Pair` is the quantity (the "value", which can be anything) returned by `dispatch(::AbstractDispatchedTuple, key)`, the one user-facing method exported by DispatchedTuples.jl.
 
-Note that the second (optional) argument to `DispatchedTuple` and `DispatchedTupleSet` is a default value, which is returned for any unrecognized keys as shown in the table above.
+Note that the second (optional) argument to `DispatchedTuple` and `DispatchedSet` is a default value, which is returned for any unrecognized keys as shown in the table above.
 
 ## Example
 
@@ -52,6 +52,6 @@ For convenience, `DispatchedTuple` can alternatively take a `Tuple` of two-eleme
 ```@docs
 DispatchedTuples.AbstractDispatchedTuple
 DispatchedTuples.DispatchedTuple
-DispatchedTuples.DispatchedTupleSet
+DispatchedTuples.DispatchedSet
 DispatchedTuples.dispatch
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,8 +1,28 @@
 # DispatchedTuples.jl
 
-DispatchedTuples.jl defines one user-facing type: `DispatchedTuple`, and one user-facing method: `dispatch`. A `DispatchedTuple` is similar to a compile-time dictionary, that uses dispatch for the look-up.
+## What are dispatched tuples?
 
-`DispatchedTuple` takes a `Tuple` of `Pair`s, where the `first` field of the `Pair` (the "key") is **an instance of the type you want to dispatch on**. The `second` field of the `Pair` is the quantity (the "value", which can be anything) returned by `dispatch`.
+`DispatchedTuple`s are like immutable dictionaries (so, they're more like `NamedTuple`s) except that the keys are **instances of types**. Also, because `DispatchedTuple`s are backed by tuples, they are GPU-friendly.
+
+There are two kinds of `DispatchedTuple`s with different behavior:
+
+```
+┌────────────────────────────────────┬───────────────────────────┬────────────────────┐
+│                       Return value │           DispatchedTuple │ DispatchedTupleSet │
+│                                    │ (non-unique keys allowed) │ (unique keys only) │
+├────────────────────────────────────┼───────────────────────────┼────────────────────┤
+│                               Type │                     Tuple │              Value │
+│ Unregistered key (without default) │                        () │              error │
+│    Unregistered key (with default) │                (default,) │            default │
+│                    Duplicative key │     all registered values │          one value │
+└────────────────────────────────────┴───────────────────────────┴────────────────────┘
+```
+
+## Creating and using dispatched tuples
+
+All `AbstractDispatchedTuple`s take a `Tuple` of `Pair`s, where the `first` field of the `Pair` (the "key") is **an instance of the type you want to dispatch on**. The `second` field of the `Pair` is the quantity (the "value", which can be anything) returned by `dispatch(::AbstractDispatchedTuple, key)`, the one user-facing method exported by DispatchedTuples.jl.
+
+Note that the second (optional) argument to `DispatchedTuple` and `DispatchedTupleSet` is a default value, which is returned for any unrecognized keys as shown in the table above.
 
 ## Example
 
@@ -12,33 +32,18 @@ Here is an example in action
 using DispatchedTuples
 struct Foo end;
 struct Bar end;
-dtup = DispatchedTuple((
-               Pair(Foo(), 1),
-               Pair(Bar(), 2),
-           ))
-
-println(dispatch(dtup, Foo()))
-println(dispatch(dtup, Bar()))
-```
-
-If a `DispatchedTuple` has duplicate keys, then all values are returned in the `Tuple`. Here's an example with duplicate keys:
-
-```@example
-using DispatchedTuples
-struct Foo end
-struct Bar end
+struct Baz end;
 
 dtup = DispatchedTuple((
-               Pair(Foo(), 1),
-               Pair(Foo(), 3),
-               Pair(Bar(), 2),
-           ))
+   Pair(Foo(), 1),
+   Pair(Foo(), 2),
+   Pair(Bar(), 3),
+));
 
-println(dispatch(dtup, Foo()))
-println(dispatch(dtup, Bar()))
+dispatch(dtup, Foo()) # returns (1, 2)
+dispatch(dtup, Bar()) # returns (3,)
+dispatch(dtup, Baz()) # returns ()
 ```
-
-The second (optional) argument to `DispatchedTuple` is a default value, which is returned for any unrecognized keys. If the default value is not given, and `dispatch` is called with a key it hasn't seen, an error is thrown.
 
 For convenience, `DispatchedTuple` can alternatively take a `Tuple` of two-element `Tuple`s.
 
@@ -48,6 +53,5 @@ For convenience, `DispatchedTuple` can alternatively take a `Tuple` of two-eleme
 DispatchedTuples.AbstractDispatchedTuple
 DispatchedTuples.DispatchedTuple
 DispatchedTuples.DispatchedTupleSet
-DispatchedTuples.DispatchedTupleDict
 DispatchedTuples.dispatch
 ```

--- a/readme_table.jl
+++ b/readme_table.jl
@@ -1,6 +1,6 @@
 using PrettyTables
 
-header = ["Return value" "DispatchedTuple" "DispatchedTupleSet"
+header = ["Return value" "DispatchedTuple" "DispatchedSet"
     "" "(non-unique keys allowed)" "(unique keys only)"]
 
 col1 = ["Type", "Unregistered key (without default)", "Unregistered key (with default)", "Duplicative key"]

--- a/readme_table.jl
+++ b/readme_table.jl
@@ -1,0 +1,18 @@
+using PrettyTables
+
+header = ["Return value" "DispatchedTuple" "DispatchedTupleSet"
+    "" "(non-unique keys allowed)" "(unique keys only)"]
+
+col1 = ["Type", "Unregistered key (without default)", "Unregistered key (with default)", "Duplicative key"]
+
+DT = ["Tuple", "()", "(default,)", "all registered values"]
+
+DTS = ["Value", "error", "default", "one value"]
+
+data = hcat(col1, DT, DTS)
+pretty_table(
+    data,
+    header,
+    header_crayon = crayon"yellow bold",
+    crop = :none,
+)

--- a/src/DispatchedTuples.jl
+++ b/src/DispatchedTuples.jl
@@ -5,7 +5,7 @@ import Base
 export AbstractDispatchedTuple, dispatch
 
 export DispatchedTuple
-export DispatchedTupleSet
+export DispatchedSet
 
 struct NoDefaults end
 
@@ -118,49 +118,49 @@ end
 end
 
 #####
-##### DispatchedTupleSet
+##### DispatchedSet
 #####
 
 """
-    DispatchedTupleSet(tup[, default_value])
+    DispatchedSet(tup[, default_value])
 
 Similar to [`DispatchedTuple`](@ref), except:
  - keys must be unique.
  - returns the value, and not a tuple of values.
  - throws an error in `dispatch` if the key is not unique (without a default value).
 """
-struct DispatchedTupleSet{T,D} <: AbstractDispatchedTuple{T, D}
+struct DispatchedSet{T,D} <: AbstractDispatchedTuple{T, D}
     tup::T
     default::D
-    function DispatchedTupleSet(tup_in::T, default=NoDefaults()) where {T<:Tuple}
+    function DispatchedSet(tup_in::T, default=NoDefaults()) where {T<:Tuple}
         tup = unwrap_pair(tup_in)
         return new{typeof(tup), typeof(default)}(tup, default)
     end
 end
 
 """
-    dispatch(::DispatchedTupleSet, type_instance)
+    dispatch(::DispatchedSet, type_instance)
 
-Dispatch on the [`DispatchedTupleSet`](@ref), based
+Dispatch on the [`DispatchedSet`](@ref), based
 on the instance of the input type `type_instance`.
 """
-@generated function dispatch(dt::DispatchedTupleSet{TT, NoDefaults}, ::T) where {TT, T}
+@generated function dispatch(dt::DispatchedSet{TT, NoDefaults}, ::T) where {TT, T}
     expr, match_count = match_expr_val(dt, TT, T)
     if match_count == 0
         return :(throw(error("No method dispatch defined for type $T")))
     elseif match_count > 1
-        return :(throw(error("DispatchedTupleSet has non-unique keys for type $T")))
+        return :(throw(error("DispatchedSet has non-unique keys for type $T")))
     else
         return expr
     end
 end
 
-@generated function dispatch(dt::DispatchedTupleSet{TT,D}, ::T) where {TT, D, T}
+@generated function dispatch(dt::DispatchedSet{TT,D}, ::T) where {TT, D, T}
     expr, match_count = match_expr_val(dt, TT, T)
     if match_count == 0
         return :(dt.default)
     elseif match_count > 1
-        return :(throw(error("DispatchedTupleSet has non-unique keys for type $T")))
+        return :(throw(error("DispatchedSet has non-unique keys for type $T")))
     else
         return expr
     end

--- a/src/DispatchedTuples.jl
+++ b/src/DispatchedTuples.jl
@@ -6,7 +6,6 @@ export AbstractDispatchedTuple, dispatch
 
 export DispatchedTuple
 export DispatchedTupleSet
-export DispatchedTupleDict
 
 struct NoDefaults end
 
@@ -60,16 +59,35 @@ of the type you want to dispatch on**. The `second` field
 of the `Pair` is the quantity (the "value", which can be
 anything) returned by `dispatch`.
 
-If a `DispatchedTuple` has duplicate keys, then all values
-are returned in the `Tuple`.
+If a `DispatchedTuple` has non-unique keys, then all values
+are returned in the returned `Tuple`.
 
 The second (optional) argument to `DispatchedTuple` is a
 default value, which is returned for any unrecognized keys.
-If the default value is not given, and `dispatch` is called
-with a key it hasn't seen, an error is thrown.
+If the default value is not given, then `dispatch` on an
+unregistered key will return an empty tuple.
 
 For convenience, `DispatchedTuple` can alternatively take a
 `Tuple` of two-element `Tuple`s.
+
+## Example
+
+```julia
+using DispatchedTuples
+struct Foo end;
+struct Bar end;
+struct Baz end;
+
+dtup = DispatchedTuple((
+   Pair(Foo(), 1),
+   Pair(Foo(), 2),
+   Pair(Bar(), 3),
+));
+
+dispatch(dtup, Foo()) # returns (1, 2)
+dispatch(dtup, Bar()) # returns (3,)
+dispatch(dtup, Baz()) # returns ()
+```
 """
 struct DispatchedTuple{T,D} <: AbstractDispatchedTuple{T, D}
     tup::T
@@ -88,10 +106,6 @@ on the instance of the input type `type_instance`.
 """
 @generated function dispatch(dt::DispatchedTuple{TT, NoDefaults}, ::T) where {TT, T}
     expr, found_match = match_expr(dt, TT, T)
-    if !found_match
-        expr = quote end
-        push!(expr.args, :(throw(error("No method dispatch defined for type $T"))))
-    end
     expr
 end
 
@@ -110,10 +124,10 @@ end
 """
     DispatchedTupleSet(tup[, default_value])
 
-Similar to `DispatchedTuple`, except:
+Similar to [`DispatchedTuple`](@ref), except:
  - keys must be unique.
  - returns the value, and not a tuple of values.
- - throws an error in `dispatch` if keys are not unique.
+ - throws an error in `dispatch` if the key is not unique (without a default value).
 """
 struct DispatchedTupleSet{T,D} <: AbstractDispatchedTuple{T, D}
     tup::T
@@ -147,49 +161,6 @@ end
         return :(dt.default)
     elseif match_count > 1
         return :(throw(error("DispatchedTupleSet has non-unique keys for type $T")))
-    else
-        return expr
-    end
-end
-
-#####
-##### DispatchedTupleDict
-#####
-
-"""
-    DispatchedTupleDict(tup[, default_value])
-
-Similar to `DispatchedTuple`, except:
- - keys need not be unique, _but_ only the last key is used
- - returns the value, and not a tuple of values.
-"""
-struct DispatchedTupleDict{T,D} <: AbstractDispatchedTuple{T, D}
-    tup::T
-    default::D
-    function DispatchedTupleDict(tup_in::T, default=NoDefaults()) where {T<:Tuple}
-        tup = unwrap_pair(tup_in)
-        return new{typeof(tup), typeof(default)}(tup, default)
-    end
-end
-
-"""
-    dispatch(::DispatchedTupleDict, type_instance)
-
-Dispatch on the [`DispatchedTupleDict`](@ref), based
-on the instance of the input type `type_instance`.
-"""
-@generated function dispatch(dt::DispatchedTupleDict{TT, NoDefaults}, ::T) where {TT, T}
-    expr, match_count = match_expr_val(dt, TT, T)
-    if match_count == 0
-        push!(expr.args, :(throw(error("No method dispatch defined for type $T"))))
-    end
-    return expr
-end
-
-@generated function dispatch(dt::DispatchedTupleDict{TT,D}, ::T) where {TT, D, T}
-    expr, match_count = match_expr_val(dt, TT, T)
-    if match_count == 0
-        return :(dt.default)
     else
         return expr
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,50 +55,50 @@ end
 end
 
 #####
-##### DispatchedTupleSet's
+##### DispatchedSet's
 #####
 
-@testset "DispatchedTupleSet - base behavior" begin
-    dt = DispatchedTupleSet(((Foo(), 1), (Bar(), 2)))
+@testset "DispatchedSet - base behavior" begin
+    dt = DispatchedSet(((Foo(), 1), (Bar(), 2)))
     @test dispatch(dt, Foo()) == 1
     @test dispatch(dt, Bar()) == 2
     @test_throws ErrorException dispatch(dt, FooBar())
 
-    dt = DispatchedTupleSet(((Foo(), 1), (Bar(), 2)), 0)
+    dt = DispatchedSet(((Foo(), 1), (Bar(), 2)), 0)
     @test dispatch(dt, Foo()) == 1
     @test dispatch(dt, Bar()) == 2
     @test dispatch(dt, FooBar()) == dt.default
 end
 
-@testset "DispatchedTupleSet - base behavior - Pair interface" begin
-    dt = DispatchedTupleSet((Pair(Foo(), 1), Pair(Bar(), 2)))
+@testset "DispatchedSet - base behavior - Pair interface" begin
+    dt = DispatchedSet((Pair(Foo(), 1), Pair(Bar(), 2)))
     @test dispatch(dt, Foo()) == 1
     @test dispatch(dt, Bar()) == 2
     @test_throws ErrorException dispatch(dt, FooBar())
 end
 
-@testset "DispatchedTupleSet - multiple values, unique keys" begin
-    dt = DispatchedTupleSet(((Foo(), 1), (Bar(), 2), (Foo(), 3)))
+@testset "DispatchedSet - multiple values, unique keys" begin
+    dt = DispatchedSet(((Foo(), 1), (Bar(), 2), (Foo(), 3)))
     @test_throws ErrorException dispatch(dt, Foo()) == 1
     @test dispatch(dt, Bar()) == 2
     @test_throws ErrorException dispatch(dt, FooBar())
 
-    dt = DispatchedTupleSet(((Foo(), 1), (Bar(), 2), (Foo(), 3)), 0)
+    dt = DispatchedSet(((Foo(), 1), (Bar(), 2), (Foo(), 3)), 0)
     @test_throws ErrorException dispatch(dt, Foo()) == 1
     @test dispatch(dt, Bar()) == 2
     @test dispatch(dt, FooBar()) == dt.default
 end
 
 @testset "DispatchedTuples - nested" begin
-    dtup_L1_a = DispatchedTupleSet(((Foo(), 1), (Bar(), 2)))
-    dtup_L1_b = DispatchedTupleSet(((Foo(), 3), (Bar(), 4)))
-    dtup_L1_c = DispatchedTupleSet(((Foo(), 5), (Bar(), 6)))
-    dtup_L1_d = DispatchedTupleSet(((Foo(), 7), (Bar(), 8)))
+    dtup_L1_a = DispatchedSet(((Foo(), 1), (Bar(), 2)))
+    dtup_L1_b = DispatchedSet(((Foo(), 3), (Bar(), 4)))
+    dtup_L1_c = DispatchedSet(((Foo(), 5), (Bar(), 6)))
+    dtup_L1_d = DispatchedSet(((Foo(), 7), (Bar(), 8)))
 
-    dtup_L2_a = DispatchedTupleSet(((Foo(), dtup_L1_a), (Bar(), dtup_L1_b)))
-    dtup_L2_b = DispatchedTupleSet(((Foo(), dtup_L1_c), (Bar(), dtup_L1_d)))
+    dtup_L2_a = DispatchedSet(((Foo(), dtup_L1_a), (Bar(), dtup_L1_b)))
+    dtup_L2_b = DispatchedSet(((Foo(), dtup_L1_c), (Bar(), dtup_L1_d)))
 
-    dtup_L3_a = DispatchedTupleSet(((Foo(), dtup_L2_a), (Bar(), dtup_L2_b)))
+    dtup_L3_a = DispatchedSet(((Foo(), dtup_L2_a), (Bar(), dtup_L2_b)))
 
     @test dispatch(dtup_L3_a, Foo(), Foo(), Foo()) == 1
     @test dispatch(dtup_L3_a, Foo(), Foo(), Bar()) == 2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,7 @@ struct FooBar end
     dt = DispatchedTuple(((Foo(), 1), (Bar(), 2)))
     @test dispatch(dt, Foo()) == (1,)
     @test dispatch(dt, Bar()) == (2,)
-    @test_throws ErrorException dispatch(dt, FooBar())
+    @test dispatch(dt, FooBar()) == ()
 
     dt = DispatchedTuple(((Foo(), 1), (Bar(), 2)), 0)
     @test dispatch(dt, Foo()) == (1,)
@@ -24,7 +24,7 @@ end
     dt = DispatchedTuple((Pair(Foo(), 1), Pair(Bar(), 2)))
     @test dispatch(dt, Foo()) == (1,)
     @test dispatch(dt, Bar()) == (2,)
-    @test_throws ErrorException dispatch(dt, FooBar())
+    @test dispatch(dt, FooBar()) == ()
 
     dt = DispatchedTuple((Pair(Foo(), 1), Pair(Bar(), 2)), 0)
     @test dispatch(dt, Foo()) == (1,)
@@ -36,7 +36,7 @@ end
     dt = DispatchedTuple(((Foo(), 1), (Bar(), 2), (Foo(), 3)))
     @test dispatch(dt, Foo()) == (1,3)
     @test dispatch(dt, Bar()) == (2,)
-    @test_throws ErrorException dispatch(dt, FooBar())
+    @test dispatch(dt, FooBar()) == ()
 end
 
 @testset "DispatchedTuples - extending" begin
@@ -52,41 +52,6 @@ end
     dt = DispatchedTuple(tup)
     @test length(dt) == length(tup)
     @test isempty(dt) == isempty(tup)
-end
-
-#####
-##### DispatchedTupleDict's
-#####
-
-@testset "DispatchedTupleDict - base behavior" begin
-    dt = DispatchedTupleDict(((Foo(), 1), (Bar(), 2)))
-    @test dispatch(dt, Foo()) == 1
-    @test dispatch(dt, Bar()) == 2
-    @test_throws ErrorException dispatch(dt, FooBar())
-
-    dt = DispatchedTupleDict(((Foo(), 1), (Bar(), 2)), 0)
-    @test dispatch(dt, Foo()) == 1
-    @test dispatch(dt, Bar()) == 2
-    @test dispatch(dt, FooBar()) == dt.default
-end
-
-@testset "DispatchedTupleDict - base behavior - Pair interface" begin
-    dt = DispatchedTupleDict((Pair(Foo(), 1), Pair(Bar(), 2)))
-    @test dispatch(dt, Foo()) == 1
-    @test dispatch(dt, Bar()) == 2
-    @test_throws ErrorException dispatch(dt, FooBar())
-end
-
-@testset "DispatchedTupleDict - multiple values, unique keys" begin
-    dt = DispatchedTupleDict(((Foo(), 1), (Bar(), 2), (Foo(), 3)))
-    @test dispatch(dt, Foo()) == 3
-    @test dispatch(dt, Bar()) == 2
-    @test_throws ErrorException dispatch(dt, FooBar())
-
-    dt = DispatchedTupleDict(((Foo(), 1), (Bar(), 2), (Foo(), 3)), 0)
-    @test dispatch(dt, Foo()) == 3
-    @test dispatch(dt, Bar()) == 2
-    @test dispatch(dt, FooBar()) == dt.default
 end
 
 #####


### PR DESCRIPTION
I repeatedly needed to look at the docs/tests to remember the difference between `DispatchedTuple` and `DispatchedTupleDict`.

This PR also renames `DispatchedTupleSet` to `DispatchedSet`.

I think this is a much cleaner interface/design, and the new table in the readme quickly helps me get oriented. cc @ali-ramadhan