### PR TITLE
Use more concise syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,12 +78,12 @@ DispatchedTuple{Tuple{Tuple{Foo,Int64},Tuple{Foo,Int64},Tuple{Bar,Int64}},Dispat
   default => ()
 
 
-julia> dispatch(dtup, Foo())
+julia> dtup[Foo()]
 (1, 2)
 
-julia> dispatch(dtup, Bar())
+julia> dtup[Bar()]
 (3,)
 
-julia> dispatch(dtup, Baz())
+julia> dtup[Baz()]
 ()
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -46,9 +46,9 @@ dtup = DispatchedTuple((
    Pair(Bar(), 3),
 ))
 
-dispatch(dtup, Foo()) # returns (1, 2)
-dispatch(dtup, Bar()) # returns (3,)
-dispatch(dtup, Baz()) # returns ()
+dtup[Foo()] # returns (1, 2)
+dtup[Bar()] # returns (3,)
+dtup[Baz()] # returns ()
 nothing
 ```
 


### PR DESCRIPTION
Not sure if this is a positive change but I thought it looked more intuitive.