### PR TITLE
Do not export dispatch, just use `getindex`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ There are two kinds of `DispatchedTuple`s with different behavior:
 2. A `Tuple` of `Pair`s + positional default
 3. A `Tuple` of 2-element `Tuple`s (the first element being the "key", and the second the "value") + positional default
 
-The `first` field of the `Pair` (the "key") is **an instance of the type you want to dispatch on**. The `second` field of the `Pair` is the quantity (the "value", which can be anything) returned by `dispatch(dtup::AbstractDispatchedTuple, key)` (or via `dtup[key]`).
+The `first` field of the `Pair` (the "key") is **an instance of the type you want to dispatch on**. The `second` field of the `Pair` is the quantity (the "value", which can be anything) returned by `dtup[key]`.
 
 A default value, if passed to `DispatchedTuple` and `DispatchedSet`, is returned for any unrecognized keys as shown in the table above.
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -4,5 +4,4 @@
 DispatchedTuples.AbstractDispatchedTuple
 DispatchedTuples.DispatchedTuple
 DispatchedTuples.DispatchedSet
-DispatchedTuples.dispatch
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -26,7 +26,7 @@ There are two kinds of `DispatchedTuple`s with different behavior:
 2. A `Tuple` of `Pair`s + positional default
 3. A `Tuple` of 2-element `Tuple`s (the first element being the "key", and the second the "value") + positional default
 
-The `first` field of the `Pair` (the "key") is **an instance of the type you want to dispatch on**. The `second` field of the `Pair` is the quantity (the "value", which can be anything) returned by `dispatch(dtup::AbstractDispatchedTuple, key)` (or via `dtup[key]`).
+The `first` field of the `Pair` (the "key") is **an instance of the type you want to dispatch on**. The `second` field of the `Pair` is the quantity (the "value", which can be anything) returned by `dtup[key]`.
 
 A default value, if passed to `DispatchedTuple` and `DispatchedSet`, is returned for any unrecognized keys as shown in the table above.
 

--- a/docs/src/performance.md
+++ b/docs/src/performance.md
@@ -26,7 +26,7 @@ dset = DispatchedSet(tupset);
 nothing
 ```
 
-Using `dispatch` on a `DispatchedTuple` is equivalent to hard-coding the intended indexes ahead of time, which means that the LLVM code is concise:
+Using `dtup[key]` on a `DispatchedTuple` is equivalent to hard-coding the intended indexes ahead of time, which means that the LLVM code is concise:
 
 ## DispatchedTuple
 
@@ -35,14 +35,14 @@ get_foo_magic(dtup) = (dtup.tup[1][2], dtup.tup[3][2])
 @code_typed get_foo_magic(dtup)
 ```
 ```@example perf
-@code_typed dispatch(dtup, Foo())
+@code_typed dtup[Foo()]
 ```
 
 ```@example perf
 @code_native get_foo_magic(dtup)
 ```
 ```@example perf
-@code_native dispatch(dtup, Foo())
+@code_native dtup[Foo()]
 ```
 
 ## DispatchedSet
@@ -52,12 +52,12 @@ get_foo_magic(dset) = dset.tup[1][2]
 @code_typed get_foo_magic(dset)
 ```
 ```@example perf
-@code_typed dispatch(dset, Foo())
+@code_typed dset[Foo()]
 ```
 
 ```@example perf
 @code_native get_foo_magic(dset)
 ```
 ```@example perf
-@code_native dispatch(dset, Foo())
+@code_native dset[Foo()]
 ```

--- a/src/DispatchedTuples.jl
+++ b/src/DispatchedTuples.jl
@@ -2,7 +2,7 @@ module DispatchedTuples
 
 import Base
 
-export AbstractDispatchedTuple, dispatch
+export AbstractDispatchedTuple
 
 export DispatchedTuple
 export DispatchedSet
@@ -57,14 +57,14 @@ A dispatch-able tuple.
 `first` field of the `Pair` (the "key") is **an instance
 of the type you want to dispatch on**. The `second` field
 of the `Pair` is the quantity (the "value", which can be
-anything) returned by `dispatch`.
+anything) returned by `dtup[key]`.
 
 If a `DispatchedTuple` has non-unique keys, then all values
 are returned in the returned `Tuple`.
 
 The second (optional) argument to `DispatchedTuple` is a
 default value, which is returned for any unrecognized keys.
-If the default value is not given, then `dispatch` on an
+If the default value is not given, then `dtup[key]` on an
 unregistered key will return an empty tuple.
 
 For convenience, `DispatchedTuple` can alternatively take a
@@ -84,9 +84,9 @@ dtup = DispatchedTuple((
    Pair(Bar(), 3),
 ));
 
-dispatch(dtup, Foo()) # returns (1, 2)
-dispatch(dtup, Bar()) # returns (3,)
-dispatch(dtup, Baz()) # returns ()
+dtup[Foo()] # returns (1, 2)
+dtup[Bar()] # returns (3,)
+dtup[Baz()] # returns ()
 ```
 """
 struct DispatchedTuple{T,D} <: AbstractDispatchedTuple{T, D}
@@ -130,7 +130,7 @@ end
 Similar to [`DispatchedTuple`](@ref), except:
  - keys must be unique.
  - returns the value, and not a tuple of values.
- - throws an error in `dispatch` if the key is not unique (without a default value).
+ - throws an error in `dtup[key]` if the key is not unique (without a default value).
 """
 struct DispatchedSet{T,D} <: AbstractDispatchedTuple{T, D}
     tup::T
@@ -174,6 +174,7 @@ end
 
 # Nested dispatch calls:
 dispatch(dt::AbstractDispatchedTuple, a, b...) = dispatch(dispatch(dt, a), b...)
+Base.getindex(dt::AbstractDispatchedTuple, a, b...) = dispatch(dt, a, b...)
 
 # Interface / extending:
 Base.isempty(dt::AbstractDispatchedTuple) = Base.isempty(dt.tup)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,25 +10,25 @@ struct FooBar end
 
 @testset "DispatchedTuples - base behavior" begin
     dt = DispatchedTuple(((Foo(), 1), (Bar(), 2)))
-    @test dispatch(dt, Foo()) == (1,)
-    @test dispatch(dt, Bar()) == (2,)
-    @test dispatch(dt, FooBar()) == ()
+    @test dt[Foo()] == (1,)
+    @test dt[Bar()] == (2,)
+    @test dt[FooBar()] == ()
 
     dt = DispatchedTuple(((Foo(), 1), (Bar(), 2)), 0)
-    @test dispatch(dt, Foo()) == (1,)
-    @test dispatch(dt, Bar()) == (2,)
-    @test dispatch(dt, FooBar()) == (dt.default,)
+    @test dt[Foo()] == (1,)
+    @test dt[Bar()] == (2,)
+    @test dt[FooBar()] == (dt.default,)
 
     # # Outer constructor with Pair's
     dt = DispatchedTuple(Pair(Foo(), 1), Pair(Bar(), 2))
-    @test dispatch(dt, Foo()) == (1,)
-    @test dispatch(dt, Bar()) == (2,)
-    @test dispatch(dt, FooBar()) == ()
+    @test dt[Foo()] == (1,)
+    @test dt[Bar()] == (2,)
+    @test dt[FooBar()] == ()
 
     dt = DispatchedTuple(Pair(Foo(), 1), Pair(Bar(), 2); default = 0)
-    @test dispatch(dt, Foo()) == (1,)
-    @test dispatch(dt, Bar()) == (2,)
-    @test dispatch(dt, FooBar()) == (dt.default,)
+    @test dt[Foo()] == (1,)
+    @test dt[Bar()] == (2,)
+    @test dt[FooBar()] == (dt.default,)
 end
 
 @testset "DispatchedTuples - base behavior - show" begin
@@ -44,21 +44,21 @@ end
 
 @testset "DispatchedTuples - base behavior - Pair interface" begin
     dt = DispatchedTuple((Pair(Foo(), 1), Pair(Bar(), 2)))
-    @test dispatch(dt, Foo()) == (1,)
-    @test dispatch(dt, Bar()) == (2,)
-    @test dispatch(dt, FooBar()) == ()
+    @test dt[Foo()] == (1,)
+    @test dt[Bar()] == (2,)
+    @test dt[FooBar()] == ()
 
     dt = DispatchedTuple((Pair(Foo(), 1), Pair(Bar(), 2)), 0)
-    @test dispatch(dt, Foo()) == (1,)
-    @test dispatch(dt, Bar()) == (2,)
-    @test dispatch(dt, FooBar()) == (dt.default,)
+    @test dt[Foo()] == (1,)
+    @test dt[Bar()] == (2,)
+    @test dt[FooBar()] == (dt.default,)
 end
 
 @testset "DispatchedTuples - multiple values" begin
     dt = DispatchedTuple(((Foo(), 1), (Bar(), 2), (Foo(), 3)))
-    @test dispatch(dt, Foo()) == (1,3)
-    @test dispatch(dt, Bar()) == (2,)
-    @test dispatch(dt, FooBar()) == ()
+    @test dt[Foo()] == (1,3)
+    @test dt[Bar()] == (2,)
+    @test dt[FooBar()] == ()
 end
 
 @testset "DispatchedTuples - extending" begin
@@ -105,44 +105,44 @@ end
 
 @testset "DispatchedSet - base behavior" begin
     dt = DispatchedSet(((Foo(), 1), (Bar(), 2)))
-    @test dispatch(dt, Foo()) == 1
-    @test dispatch(dt, Bar()) == 2
-    @test_throws ErrorException dispatch(dt, FooBar())
+    @test dt[Foo()] == 1
+    @test dt[Bar()] == 2
+    @test_throws ErrorException dt[FooBar()]
 
     dt = DispatchedSet(((Foo(), 1), (Bar(), 2)), 0)
-    @test dispatch(dt, Foo()) == 1
-    @test dispatch(dt, Bar()) == 2
-    @test dispatch(dt, FooBar()) == dt.default
+    @test dt[Foo()] == 1
+    @test dt[Bar()] == 2
+    @test dt[FooBar()] == dt.default
 
     # # Outer constructor with Pair's
     dt = DispatchedSet(Pair(Foo(), 1), Pair(Bar(), 2))
-    @test dispatch(dt, Foo()) == 1
-    @test dispatch(dt, Bar()) == 2
-    @test_throws ErrorException dispatch(dt, FooBar())
+    @test dt[Foo()] == 1
+    @test dt[Bar()] == 2
+    @test_throws ErrorException dt[FooBar()]
 
     dt = DispatchedSet(Pair(Foo(), 1), Pair(Bar(), 2); default = 0)
-    @test dispatch(dt, Foo()) == 1
-    @test dispatch(dt, Bar()) == 2
-    @test dispatch(dt, FooBar()) == dt.default
+    @test dt[Foo()] == 1
+    @test dt[Bar()] == 2
+    @test dt[FooBar()] == dt.default
 end
 
 @testset "DispatchedSet - base behavior - Pair interface" begin
     dt = DispatchedSet((Pair(Foo(), 1), Pair(Bar(), 2)))
-    @test dispatch(dt, Foo()) == 1
-    @test dispatch(dt, Bar()) == 2
-    @test_throws ErrorException dispatch(dt, FooBar())
+    @test dt[Foo()] == 1
+    @test dt[Bar()] == 2
+    @test_throws ErrorException dt[FooBar()]
 end
 
 @testset "DispatchedSet - multiple values, unique keys" begin
     dt = DispatchedSet(((Foo(), 1), (Bar(), 2), (Foo(), 3)))
-    @test_throws ErrorException dispatch(dt, Foo()) == 1
-    @test dispatch(dt, Bar()) == 2
-    @test_throws ErrorException dispatch(dt, FooBar())
+    @test_throws ErrorException dt[Foo()] == 1
+    @test dt[Bar()] == 2
+    @test_throws ErrorException dt[FooBar()]
 
     dt = DispatchedSet(((Foo(), 1), (Bar(), 2), (Foo(), 3)), 0)
-    @test_throws ErrorException dispatch(dt, Foo()) == 1
-    @test dispatch(dt, Bar()) == 2
-    @test dispatch(dt, FooBar()) == dt.default
+    @test_throws ErrorException dt[Foo()] == 1
+    @test dt[Bar()] == 2
+    @test dt[FooBar()] == dt.default
 end
 
 @testset "DispatchedTuples - nested" begin
@@ -156,12 +156,12 @@ end
 
     dtup_L3_a = DispatchedSet(((Foo(), dtup_L2_a), (Bar(), dtup_L2_b)))
 
-    @test dispatch(dtup_L3_a, Foo(), Foo(), Foo()) == 1
-    @test dispatch(dtup_L3_a, Foo(), Foo(), Bar()) == 2
-    @test dispatch(dtup_L3_a, Foo(), Bar(), Foo()) == 3
-    @test dispatch(dtup_L3_a, Foo(), Bar(), Bar()) == 4
-    @test dispatch(dtup_L3_a, Bar(), Foo(), Foo()) == 5
-    @test dispatch(dtup_L3_a, Bar(), Foo(), Bar()) == 6
-    @test dispatch(dtup_L3_a, Bar(), Bar(), Foo()) == 7
-    @test dispatch(dtup_L3_a, Bar(), Bar(), Bar()) == 8
+    @test dtup_L3_a[Foo(), Foo(), Foo()] == 1
+    @test dtup_L3_a[Foo(), Foo(), Bar()] == 2
+    @test dtup_L3_a[Foo(), Bar(), Foo()] == 3
+    @test dtup_L3_a[Foo(), Bar(), Bar()] == 4
+    @test dtup_L3_a[Bar(), Foo(), Foo()] == 5
+    @test dtup_L3_a[Bar(), Foo(), Bar()] == 6
+    @test dtup_L3_a[Bar(), Bar(), Foo()] == 7
+    @test dtup_L3_a[Bar(), Bar(), Bar()] == 8
 end


### PR DESCRIPTION
Closes #21. I'm not going to deprecate `dispatch`, since we're still pretty early in dev (despite this being a breaking change 😬 ).