### PR TITLE
Bump version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DispatchedTuples"
 uuid = "508c55e1-51b4-41fd-a5ca-7eb0327d070d"
 authors = ["Charles Kawczynski <kawczynski.charles@gmail.com>"]
-version = "0.1.5"
+version = "0.2.0"
 
 [compat]
 julia = "1.5"


### PR DESCRIPTION
Bumping for release. Bumping the minor version since, based on [this post](https://discourse.julialang.org/t/please-be-mindful-of-version-bounds-and-semantic-versioning-when-tagging-your-packages/30708), there are breaking changes (`dispatch` is no longer exported).