### PR TITLE
Make show more terse

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DispatchedTuples"
 uuid = "508c55e1-51b4-41fd-a5ca-7eb0327d070d"
 authors = ["Charles Kawczynski <kawczynski.charles@gmail.com>"]
-version = "0.2.0"
+version = "0.2.1"
 
 [compat]
 julia = "1.5"

--- a/README.md
+++ b/README.md
@@ -67,11 +67,11 @@ julia> struct Bar end;
 julia> struct Baz end;
 
 julia> dtup = DispatchedTuple((
-         Pair(Foo(), 1),
-         Pair(Foo(), 2),
-         Pair(Bar(), 3),
-       ))
-DispatchedTuple{Tuple{Tuple{Foo,Int64},Tuple{Foo,Int64},Tuple{Bar,Int64}},DispatchedTuples.NoDefaults} with 3 entries:
+                Pair(Foo(), 1),
+                Pair(Foo(), 2),
+                Pair(Bar(), 3),
+              ))
+DispatchedTuple with 3 entries:
   Foo() => 1
   Foo() => 2
   Bar() => 3

--- a/src/DispatchedTuples.jl
+++ b/src/DispatchedTuples.jl
@@ -209,7 +209,7 @@ show_default(io::IO, dt::DispatchedTuple, ::NoDefaults) = println(io, "  default
 show_default(io::IO, dt::DispatchedSet, ::NoDefaults) = println(io, "  default => error")
 
 function Base.show(io::IO, dt::AbstractDispatchedTuple)
-    show(io, typeof(dt))
+    print(io, "$(nameof(typeof(dt)))")
     print(io, " with $(length(dt)) entries:")
     println(io)
     foreach(dt) do tup


### PR DESCRIPTION
I've found that working with `DispatchedTuple`s in practice, `show` can be quite verbose. For example, in the README, printing the type alone for 3 entries reads `DispatchedTuple{Tuple{Tuple{Foo,Int64},Tuple{Foo,Int64},Tuple{Bar,Int64}},DispatchedTuples.NoDefaults}`. This PR removes printing `typeof` information in `show`.