### PR TITLE
Allow getindex with types (specialization)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DispatchedTuples"
 uuid = "508c55e1-51b4-41fd-a5ca-7eb0327d070d"
 authors = ["Charles Kawczynski <kawczynski.charles@gmail.com>"]
-version = "0.2.1"
+version = "0.2.2"
 
 [compat]
 julia = "1.5"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,6 +29,11 @@ struct FooBar end
     @test dt[Foo()] == (1,)
     @test dt[Bar()] == (2,)
     @test dt[FooBar()] == (dt.default,)
+
+    dt = DispatchedTuple(Pair(Foo(), 1), Pair(Bar(), 2); default = 0)
+    @test dt[Foo] == (1,)
+    @test dt[Bar] == (2,)
+    @test dt[FooBar] == (dt.default,)
 end
 
 @testset "DispatchedTuples - base behavior - show" begin
@@ -136,6 +141,11 @@ end
     @test dt[Foo()] == 1
     @test dt[Bar()] == 2
     @test dt[FooBar()] == dt.default
+
+    dt = DispatchedSet(Pair(Foo(), 1), Pair(Bar(), 2); default = 0)
+    @test dt[Foo] == 1
+    @test dt[Bar] == 2
+    @test dt[FooBar] == dt.default
 end
 
 @testset "DispatchedSet - base behavior - Pair interface" begin


### PR DESCRIPTION
This PR adds support for `getindex` with types. Note that we still need instances when creating a DispatchedTuple, but now we can retrieve values with types in addition to instances of types.